### PR TITLE
Bugfix kernel oops on tty mx close race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ modules.order
 test/vtty_test
 test/pty_test
 test/portmirror
+/vtty.mod

--- a/Kbuild
+++ b/Kbuild
@@ -4,3 +4,4 @@
 #
 
 obj-m := vtty.o
+#ccflags-y := -DDEBUG -g

--- a/Kbuild
+++ b/Kbuild
@@ -1,0 +1,6 @@
+# Kbuild
+#  Created on: 16.03.2023
+#      Author: joluxer
+#
+
+obj-m := vtty.o

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-obj-m := vtty.o
-KVERSION := $(shell uname -r)
+KVERSION ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KVERSION)/build
 
 all: vtty.c
-	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
 
 clean:
-	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
-obj-m := vtty.o
-KVERSION := $(shell uname -r)
+KVERSION ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KVERSION)/build
 
-all: vtty.c
-	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD) modules
+modules: vtty.c vtty.h
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+modules_install: modules
+	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
+
+all: modules
 
 clean:
-	$(MAKE) -C /lib/modules/$(KVERSION)/build M=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ include:
 - PTY supports locking/unlocking access to the pseudo-tty using TIOCSPTLCK. This is not supported in VTTY
 
 
+Build for user-mode linux
+-------------------------
+
+For debugging purposes, any kind of virtualization etc., it is possible to use this module also in user-mode linux.
+
+Therefor you can "cross-compile" it like any other architecture, as a user mode module.
+
+When you built your um-kernel in ``~/user-mode-linux/build_uml-$(uname -r)``, then you can build this module like this:
+
+```
+$ cd vtty
+$ make KDIR=~/user-mode-linux/build_uml-$(uname -r) ARCH=um
+```
+
+
 Known bugs
 ----------
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,8 @@
 all: vtty_test pty_test portmirror
 
 %: %.c ../vtty.h
-	gcc -o $@ $^ -I .. -Wall
+	gcc -g -o $@ $^ -I .. -Wall
 
 pty_test: vtty_test.c ../vtty.h
-	gcc -o $@ $^ -I .. -Wall -DTEST_ON_PTY
+	gcc -g -o $@ $^ -I .. -Wall -DTEST_ON_PTY
 

--- a/test/vtty_test.c
+++ b/test/vtty_test.c
@@ -116,7 +116,7 @@ void open_vtmx(int *mx)
 
 void open_vtty(int *tty)
 {
-	*tty = open(SLAVE_PATH, O_RDWR);
+	*tty = open(SLAVE_PATH, O_RDWR | O_CLOEXEC | O_NOCTTY);
 	t_assert(*tty >= 0);
 	tty_set_raw(*tty);
 }
@@ -752,7 +752,7 @@ void t18_vtmx_oob_not_lost()
 {
 	int mx, tty;
 	char buf[100];
-	t_begin("VTMX out-of-bounds data should not be lost");
+	t_begin("VTMX out-of-band data should not be lost");
 	open_pair(&mx, &tty);
 	drain(mx); // tcsetattr will happen on open
 

--- a/udev.rules.d/70-vtty.rules
+++ b/udev.rules.d/70-vtty.rules
@@ -1,0 +1,6 @@
+KERNEL!="vtmx|ttyV[0-9]*", GOTO="_vtty_end"
+
+ACTION=="add", SUBSYSTEMS=="misc", KERNEL=="vtmx", GROUP="dialout", MODE="0660"
+ACTION=="add", SUBSYSTEMS=="misc", KERNEL=="ttyV[0-9]*", GROUP="dialout", MODE="0660"
+
+LABEL="_vtty_end"

--- a/vtty.c
+++ b/vtty.c
@@ -11,6 +11,7 @@
  *      (at your option) any later version.
  */
 #include <linux/module.h>
+#include <linux/moduleparam.h>
 #include <linux/tty.h>
 #include <linux/tty_flip.h>
 #include <linux/mutex.h>
@@ -695,7 +696,7 @@ static int __init vtty_init(void)
 		goto fail_deregister;
 	}
 
-	vtty_driver->driver_name = "vtty";
+	vtty_driver->driver_name = module_name(THIS_MODULE);
 	vtty_driver->name = "ttyV";
 	vtty_driver->type = TTY_DRIVER_TYPE_SERIAL;
 	vtty_driver->subtype = SERIAL_TYPE_NORMAL;
@@ -731,3 +732,5 @@ static void __exit vtty_exit(void)
 module_init(vtty_init);
 module_exit(vtty_exit);
 MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Andrzej Szombierski <qq@kuku.eu.org>");
+MODULE_DESCRIPTION("Virtual serial port driver.");

--- a/vtty.c
+++ b/vtty.c
@@ -135,7 +135,7 @@ static int vtty_write(struct tty_struct *tty, const unsigned char *buf, int coun
 
 	wake_up_interruptible_sync_poll(&port->read_wait, POLLIN | POLLRDNORM);
 	spin_unlock_irqrestore(&port->port.lock, flags);
-	
+
 	pr_debug("Written %d (cste=%d)\n", ret, CIRC_SPACE_TO_END(circ->head, circ->tail, VTTY_XMIT_SIZE));
 	return ret;
 }
@@ -174,7 +174,7 @@ static int vtty_wait_oob(struct vtty_port *port, unsigned long *pflags)
 	DEFINE_WAIT(wait);
 
 	while(port->oob_size != 0) {
-		if (signal_pending(current)) 
+		if (signal_pending(current))
 			return -ERESTARTSYS;
 
 		prepare_to_wait(&port->oob_wait, &wait, TASK_INTERRUPTIBLE);
@@ -290,10 +290,10 @@ static int vtty_create_port(int index)
 	struct device *dev;
 	unsigned long page;
 	int ret = 0;
-	
+
 	tty_port_init(&port->port);
 	tty_buffer_set_limit(&port->port, 8192);
-	
+
 	page = get_zeroed_page(GFP_KERNEL);
 	if (!page) {
 		ret = -ENOMEM;
@@ -408,7 +408,7 @@ static ssize_t vtmx_read (struct file *filp, char __user *ptr, size_t size, loff
 	int ret = 0;
 	DEFINE_WAIT(wait);
 
-	if(size < 1 + sizeof(union vtty_oob_data)) 
+	if(size < 1 + sizeof(union vtty_oob_data))
 		return -EMSGSIZE; // don't bother with clueless userspace apps
 
 	spin_lock_irqsave(&port->port.lock, flags);
@@ -453,7 +453,7 @@ static ssize_t vtmx_read (struct file *filp, char __user *ptr, size_t size, loff
 					ret = -EFAULT;
 					break;
 				}
-				
+
 				port->oob_size = 0;
 				wake_up_interruptible_sync(&port->oob_wait);
 				break;
@@ -499,7 +499,7 @@ static ssize_t vtmx_read (struct file *filp, char __user *ptr, size_t size, loff
 			++ptr;
 			--size;
 		}
-		
+
 		if(c > size)
 			c = size;
 
@@ -524,9 +524,9 @@ static ssize_t vtmx_read (struct file *filp, char __user *ptr, size_t size, loff
 		} else
 			pr_debug("no tty_wakeup\n");
 	}
-	
+
 	mutex_unlock(&portlock);
-	
+
 	return ret;
 }
 
@@ -621,12 +621,12 @@ static unsigned int vtmx_poll(struct file *filp, poll_table *wait)
 	// is there anything to read?
 	if(CIRC_CNT_TO_END(circ->head, circ->tail, VTTY_XMIT_SIZE) > 0)
 		mask |= POLLIN | POLLRDNORM;
-	
+
 	// any oob data?
-	if(port->oob_size > 0) 
+	if(port->oob_size > 0)
 		mask |= POLLIN | POLLRDNORM | POLLPRI;
 
-	if(tty_buffer_space_avail(&port->port) > 0) 
+	if(tty_buffer_space_avail(&port->port) > 0)
 		mask |= POLLOUT | POLLWRNORM;
 
 	pr_debug("poll() (%d, %d) return %x\n", (int)CIRC_CNT_TO_END(circ->head, circ->tail, VTTY_XMIT_SIZE), (int)port->oob_size, (int)mask);
@@ -654,7 +654,7 @@ static long vtmx_ioctl(struct file * filp, unsigned int cmd, unsigned long arg)
 	struct vtty_port *port = filp->private_data;
 
 	switch(cmd) {
-	case VTMX_GET_VTTY_NUM: 
+	case VTMX_GET_VTTY_NUM:
 		return put_user(port - ports, (unsigned int __user *)arg);
 
 	case VTMX_SET_MODEM_LINES:
@@ -744,8 +744,11 @@ static void __exit vtty_exit(void)
 }
 
 module_param(user_break_timing, bool, 0444);
+MODULE_PARM_DESC(user_break_timing, " set true, if the vtty provider can do break signal timing, defaults to Y");
 module_param(tty_name_template, charp, 0444);
+MODULE_PARM_DESC(tty_name_template, " the vtty slave name template for the vtty's, defaults to 'ttyV'");
 module_param(mux_name, charp, 0444);
+MODULE_PARM_DESC(mux_name, " the vtty master name, defaults to 'vtmx'");
 
 module_init(vtty_init);
 module_exit(vtty_exit);

--- a/vtty.c
+++ b/vtty.c
@@ -719,6 +719,8 @@ static int __init vtty_init(void)
 	if(ret)
 		goto fail_put;
 
+	memset(ports, 0, sizeof(ports));
+
 	mutex_init(&portlock);
 
 	return ret;


### PR DESCRIPTION
A sequel to my previous PRs, offering my bugfixes on kernel OOPSes. 

There was a data destruction race or at least kind of, which ended up in kernel OOPS, when the master side of a VTTY was closed before the slave side. Serialization and delayed destruction of the data helped out of this situation. 

I tried to dedicate every single commit to a subject of my modifications for easier review.

This PR incorporates the previous requests, so please, merge in order or ask for rebasing my PRs. Sometimes I mess things up, 'cause git is not my primary eco system.
