### PR TITLE
fix for kernel 6.1

### DIFF
--- a/vtty.c
+++ b/vtty.c
@@ -450,7 +450,7 @@ static ssize_t vtmx_read (struct file *filp, char __user *ptr, size_t size, loff
 				size--;
 
 				if(tag == TAG_SET_TERMIOS) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,2,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,1,0)
 					copystatus = kernel_termios_to_user_termios((struct termios2 __user*)ptr, &port->oob_data.termios);
 #else
 #ifdef CONFIG_SPARC


### PR DESCRIPTION
https://github.com/anszom/vtty/pull/12 is not sufficient.

Up to kernel 6.0 `kernel_termios_to_user_termios` was defined as `copy_to_user(u, k, sizeof(struct termios2))`:
https://github.com/torvalds/linux/blob/v6.0/include/asm-generic/termios.h#L77-L81.

I guess we could just skip this version check and just use `copy_to_user` for all versions? In any case, this fixes the build also for kernels 6.1.