### PR TITLE
udev rule

### DIFF
--- a/50-vtty.rules
+++ b/50-vtty.rules
@@ -1,0 +1,4 @@
+# master
+SUBSYSTEM=="misc", KERNEL=="vtmx", GROUP="dialout"
+# slaves
+SUBSYSTEM=="tty", KERNEL=="ttyV[0-9]*", GROUP="dialout"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ modules: vtty.c vtty.h
 
 modules_install: modules
 	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
+	install -m 644 50-vtty.rules /usr/lib/udev/rules.d
 
 all: modules
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ modules: vtty.c vtty.h
 
 modules_install: modules
 	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
+	depmod -A
 	install -m 644 50-vtty.rules /usr/lib/udev/rules.d
 
 all: modules

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This kernel module allows userspace programs to create virtual serial ports unde
 
 This is somewhat similar to the regular pseudo-tty interface, but vtty also emulates characteristics
 such as baud rate & modem line state. This allows users to create a fully-functional serial port
-driver completely in userspace. 
+driver completely in userspace.
 
 Possible uses:
 - forward a serial port over the network. There are several Linux implementations of a RFC2217 server.
@@ -20,12 +20,12 @@ Userspace interface
 
 The module creates a **/dev/vtmx** "master" device, which is used to create the virtual serial ports in a
 manner similar to the pseudo-tty master device /dev/ptmx. Opening the **/dev/vtmx** device causes a
-**/dev/ttyV#** device to be allocated. The index of the virtual port can be obtained by issuing a 
-**VTMX_GET_VTTY_NUM** (equal to TIOCGPTN) ioctl on the vtmx file descriptor. 
+**/dev/ttyV#** device to be allocated. The index of the virtual port can be obtained by issuing a
+**VTMX_GET_VTTY_NUM** (equal to TIOCGPTN) ioctl on the vtmx file descriptor.
 
 Any writes on the vtmx file descriptor will appear as incoming data on the virtual TTY, subject to the
 regular in-kernel processing (line disciplines, echoing, and so on). Reading from vtmx will return data
-in a "packetized" format, inspired by the obscure pseudo-tty "packet" mode. On each successful read() call, 
+in a "packetized" format, inspired by the obscure pseudo-tty "packet" mode. On each successful read() call,
 the first byte returned will indicate the type of packet returned.
 
 Currently supported packet formats:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Possible uses:
 - split one physical serial port in two, allowing two apps to access it without conflict (for example
   gdb & minicom, or esptool & minicom)
 
+Installation
+------------
+```
+sudo -E make modules_install
+sudo modprobe vtty
+```
 
 Userspace interface
 -------------------

--- a/vtty.c
+++ b/vtty.c
@@ -450,7 +450,7 @@ static ssize_t vtmx_read (struct file *filp, char __user *ptr, size_t size, loff
 				size--;
 
 				if(tag == TAG_SET_TERMIOS) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,2,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,1,0)
 					copystatus = kernel_termios_to_user_termios((struct termios2 __user*)ptr, &port->oob_data.termios);
 #else
 #ifdef CONFIG_SPARC


### PR DESCRIPTION
This adds and installs an udev rule to set the group permissions for the master and slave devices to `dialout`. This way, regular users of the `dialout` group can access the devices, similar to how they would access real serial devices.

I also documented how to build & install the module as this requires forwarding environment variables to the root shell via `-E`.

Note: This contains https://github.com/anszom/vtty/pull/14. Therefore, https://github.com/anszom/vtty/pull/14 should be merged first.

Fixes #13 .