### PR TITLE
tty_operations and file_operations fixes for Linux 6.12

### DIFF
--- a/vtty.c
+++ b/vtty.c
@@ -105,7 +105,11 @@ static void vtty_close(struct tty_struct *tty, struct file *filp)
 	return;
 }
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6,6,0)
+static ssize_t vtty_write(struct tty_struct *tty, const u8 *buf, size_t count)
+#else
 static int vtty_write(struct tty_struct *tty, const unsigned char *buf, int count)
+#endif
 {
 	// the TTY layer manages -EAGAIN and (non-)blocking writes
 	struct vtty_port *port = &ports[tty->index];

--- a/vtty.c
+++ b/vtty.c
@@ -684,7 +684,9 @@ static long vtmx_ioctl(struct file * filp, unsigned int cmd, unsigned long arg)
 
 static struct file_operations vtmx_fops = {
 	.owner 		= THIS_MODULE,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,0,0)
 	.llseek		= no_llseek,
+#endif
 	.read		= vtmx_read,
 	.write		= vtmx_write,
 	.poll		= vtmx_poll,


### PR DESCRIPTION
As of Linux v6.6 the definition for tty_operations::write uses size_t to
unify with other tty_operations.

As of Linux v6.0 all calls to ->llseek are called through vfs_llseek and
setting no_llseek is equivalent to leaving it as NULL. The definition of
no_llseek was removed in v6.12.

Signed-off-by: Terin Stock <terin@terinstock.com>